### PR TITLE
feat(mainnet): add update-consensus-block-max-gas proposals

### DIFF
--- a/proposals/mainnet/0010-update-consensus-block-max-gas/proposal.json
+++ b/proposals/mainnet/0010-update-consensus-block-max-gas/proposal.json
@@ -1,0 +1,30 @@
+{
+    "messages": [
+     {
+      "@type": "/cosmos.consensus.v1.MsgUpdateParams",
+      "authority": "ethm10d07y265gmmuvt4z0w9aw880jnsr700jpva843",
+      "block": {
+           "max_bytes": "22020096",
+           "max_gas": "21000000"
+         },
+       "evidence": {
+           "max_age_num_blocks": "100000",
+           "max_age_duration": "172800000000000ns",
+           "max_bytes": "1048576"
+       },
+       "validator": {
+       "pub_key_types": [
+           "ed25519"
+       ]
+       },
+      "abci": {
+           "vote_extensions_enable_height": "0"
+         }
+     }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "1000000000000000000000axrp",
+    "title": "Update Consensus Block Max Gas",
+    "summary": "During the genesis phase of mainnet deployments, the consensus parameters were not properly set. As a result, the provided configuration was overridden by default values from CometBFT. We propose to cap the block.max_gas value to 21,000,000, which approximates the gas required for ~1,000 typical Ethereum transactions.",
+    "expedited": true
+   }


### PR DESCRIPTION
# Issue Report: Incorrect Consensus Parameters on Genesis

## Summary
During the **genesis phase** of both **testnet** and **mainnet** deployments, the consensus parameters were not properly set. As a result, the provided configuration was **overridden by default values** from **CometBFT**.

## Impact
This means that the maximum gas per block was set to `infinite`, instead of the intended `10,500,000`.
Consequently, some transactions have consumed unexpectedly high amounts of gas, leading to potential inconsistencies in block performance and transaction costs.

## Root Cause

The genesis initialization did not correctly apply the consensus parameters.

CometBFT’s default values replaced the intended configuration. See [link](https://github.com/cometbft/cometbft/blob/d03254d3599b973f979314e6383b89fa1802e679/types/params.go#L96-L132)

```json
{
    "block": {
        "max_bytes":"22020096",
        "max_gas":"-1"
    },
    "evidence": {
        "max_age_num_blocks":"100000",
        "max_age_duration":"172800000000000",
        "max_bytes":"1048576"
    },
    "validator": {
        "pub_key_types":["ed25519"]
    },
    "version": {
        "app":"0"
    },
    "abci":{"vote_extensions_enable_height":"0"}
}
```

## Proposed Solution

We propose to cap the `block.max_gas` value to `21,000,000`, which approximates the gas required for ~1,000 typical Ethereum transactions.

This adjustment will:

* Enforce a realistic gas limit per block.
* Prevent excessive gas usage by large or complex transactions.
* Align block gas behavior with expected network conditions.

## Proposal 

```json
{
 "messages": [
  {
   "@type": "/cosmos.consensus.v1.MsgUpdateParams",
   "authority": "ethm10d07y265gmmuvt4z0w9aw880jnsr700jpva843",
   "block": {
        "max_bytes": "22020096",
        "max_gas": "21000000"
      },
    "evidence": {
        "max_age_num_blocks": "100000",
        "max_age_duration": "172800000000000ns",
        "max_bytes": "1048576"
    },
    "validator": {
    "pub_key_types": [
        "ed25519"
    ]
    },
   "abci": {
        "vote_extensions_enable_height": "0"
      }
  }
 ],
 "metadata": "ipfs://CID",
 "deposit": "1000000000000000000000axrp",
 "title": "Update Consensus Block Max Gas",
 "summary": "During the genesis phase of mainnet deployments, the consensus parameters were not properly set. As a result, the provided configuration was overridden by default values from CometBFT. 
We propose to cap the block.max_gas value to 21,000,000, which approximates the gas required for ~1,000 typical Ethereum transactions.",
 "expedited": true
}
```
